### PR TITLE
Remove BLASTTranslator.txt, DOE2Translator.txt and ParametricSpreadsheets.txt files and associated directories.

### DIFF
--- a/bin/Windows/PreProcess/BLASTTranslator/BLASTTranslator.txt
+++ b/bin/Windows/PreProcess/BLASTTranslator/BLASTTranslator.txt
@@ -1,8 +1,0 @@
-You need to obtain the "BLAST Translator" from the EnergyPlus website.
-
-http://apps1.eere.energy.gov/buildings/energyplus/energyplus_addons.cfm
-
-Under Additional Release Components will be instructions.
-
-BLASTTranslator.zip
-

--- a/bin/Windows/PreProcess/DOE2Translator/DOE2Translator.txt
+++ b/bin/Windows/PreProcess/DOE2Translator/DOE2Translator.txt
@@ -1,8 +1,0 @@
-You need to obtain the "DOE-2 Translator" from the EnergyPlus website.
-
-http://apps1.eere.energy.gov/buildings/energyplus/energyplus_addons.cfm
-
-Additional Release Components will give you the information.
-
-DOE2Translator.zip
-

--- a/bin/Windows/PreProcess/ParametricSpreadsheets/ParametricSpreadsheets.txt
+++ b/bin/Windows/PreProcess/ParametricSpreadsheets/ParametricSpreadsheets.txt
@@ -1,9 +1,0 @@
-You need to obtain the "spreadsheets" from the EnergyPlus website.
-
-http://apps1.eere.energy.gov/buildings/energyplus/energyplus_addons.cfm
-
-Under Additional Release Components will be instructions.
-
-g-function_library.zip -- g-functions spreadsheet
-HeatPump_WatertoWater_WatertoAir_SpreadsheetsAndDocs.zip (spreadsheets and docs for Water to Water and Water to Air estimators)
-


### PR DESCRIPTION
This is part of addressing https://github.com/NREL/EnergyPlus/issues/5423 by relocating the references to the DOE2 translator, BLAST translator and Parametric Spreadsheets from small text files to part of the documentation. 